### PR TITLE
fix: Dockerfile installing the required dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Start from Ubuntu
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 # Copy over PascalX
 COPY . /PascalX
@@ -7,16 +6,28 @@ COPY . /PascalX
 # Install dependencies
 RUN mkdir -p /PascalX/build/lib
 ENV DEBIAN_FRONTEND="noninteractive"
-RUN apt-get update && apt-get install -y python3.11 python3-dev python3-setuptools python3-pip python3-numpy g++ make libboost-all-dev wget unzip
+RUN apt-get update && \
+    apt-get install -y \
+    python3.11 \
+    python3.11-dev \
+    python3-setuptools \
+    python3-pip \
+    python3-numpy \
+    g++ \
+    make \
+    libboost-all-dev \
+    wget \
+    unzip \
+    python3-pybind11 \
+    python3-matplotlib \
+    python3-pandas && \
+    rm -rf /var/lib/apt/lists/*
+RUN ln -sf /usr/bin/python3.11 /usr/local/bin/python3
 RUN echo "/PascalX/build/lib" > /etc/ld.so.conf.d/pascalx.conf
 
 # Build
 RUN cd /PascalX && make all && ldconfig && make test
-RUN apt-get update && apt-get install -y python3-pybind11
-RUN apt-get update && apt-get install -y python3-matplotlib
-RUN apt-get update && apt-get install -y python3-pandas
 RUN cd /PascalX/python/ && python3 setup.py install
 
 # Install jupyter
-RUN pip3 install jupyter
-
+RUN python3 -m pip install jupyter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from Ubuntu
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # Copy over PascalX
 COPY . /PascalX
@@ -7,11 +7,14 @@ COPY . /PascalX
 # Install dependencies
 RUN mkdir -p /PascalX/build/lib
 ENV DEBIAN_FRONTEND="noninteractive"
-RUN apt-get update && apt-get install -y python3 python3-dev python3-setuptools python3-pip g++ make libboost-all-dev wget unzip
+RUN apt-get update && apt-get install -y python3.11 python3-dev python3-setuptools python3-pip python3-numpy g++ make libboost-all-dev wget unzip
 RUN echo "/PascalX/build/lib" > /etc/ld.so.conf.d/pascalx.conf
 
 # Build
 RUN cd /PascalX && make all && ldconfig && make test
+RUN apt-get update && apt-get install -y python3-pybind11
+RUN apt-get update && apt-get install -y python3-matplotlib
+RUN apt-get update && apt-get install -y python3-pandas
 RUN cd /PascalX/python/ && python3 setup.py install
 
 # Install jupyter


### PR DESCRIPTION
When building the original image I found the following problem:

``` bash
docker build --platform linux/amd64 -t pascalx .
```
```
...
86.06 error: Couldn't find a setup script in /tmp/easy_install-ttl3y4_a/matplotlib-3.10.6.tar.gz
------
Dockerfile:15
--------------------
  13 |     # Build
  14 |     RUN cd /PascalX && make all && ldconfig && make test
  15 | >>> RUN cd /PascalX/python/ && python3 setup.py install
  16 |
  17 |     # Install jupyter
--------------------
ERROR: failed to solve: process "/bin/sh -c cd /PascalX/python/ && python3 setup.py install" did not complete successfully: exit code: 1
```

The proposed changes fix the building process successful by tightening some of the dependencies and adding missing ones.